### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VG487FGV17"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VG487FGV17');
+  </script>
 </head>
 <body>
   <div class="site-bg"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -177,3 +177,14 @@ const GALLERY_ITEMS = [
   startTimer();
   if(toggle){ toggle.addEventListener('click', ()=>{ expanded = !expanded; applyAbout(); }); }
 })();
+
+// Track site interaction events with Google Analytics
+document.addEventListener('click', (e) => {
+  const el = e.target.closest('a, button, .thumb');
+  if (!el || typeof gtag !== 'function') return;
+  let label = el.getAttribute('href') || el.getAttribute('alt') || el.id || (el.textContent || '').trim();
+  gtag('event', 'interaction', {
+    event_category: 'site',
+    event_label: label
+  });
+});

--- a/links.html
+++ b/links.html
@@ -8,6 +8,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/styles.css" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VG487FGV17"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VG487FGV17');
+  </script>
   <style>
     /* page-specific tweak so links page is dark without the main gradient */
     body.links-body { background: #0c0c0f; }
@@ -60,5 +68,6 @@
       <a href="mailto:contact@niemans.website" class="tiny-link">contact@niemans.website</a>
     </p>
   </main>
+  <script src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Google Analytics snippet (G-VG487FGV17) to index and links pages
- Include main script on links page and log site interactions as GA events

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899570d764c8328a5f1bfca18f876e4