### PR TITLE
Add unmute button for gallery videos

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -107,6 +107,9 @@ body{
 /* Caption overlay */
 .caption{ position:absolute; left:0; right:0; bottom:0; padding:10px 14px; font-size:.9rem; color:#eaeaf0; background:linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.78) 85%, rgba(0,0,0,.92) 100%); z-index:5; pointer-events:none; }
 
+/* Unmute button */
+.unmute-btn{position:absolute; bottom:0.5rem; right:0.5rem; padding:0.25rem 0.5rem; background:rgba(0,0,0,0.6); color:#fff; border:none; border-radius:4px; cursor:pointer;}
+
 /* CONTENT */
 .content{padding:28px 0 80px}
 .section-title{font-weight:900; letter-spacing:2px; font-size:clamp(16px, 2.8vw, 22px); margin:34px 0 18px; text-transform:uppercase; color:#e9e9f2}

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
         <img id="g-main-a" class="slide-img slide-media is-active" src="assets/gallery/1.jpg" alt="Memories at The Getaway" width="360" height="640" />
         <img id="g-main-b" class="slide-img slide-media" alt="" width="360" height="640" />
         <figcaption id="g-cap" class="caption">Memories at The Getaway</figcaption>
+        <button id="unmuteBtn" class="unmute-btn" aria-label="Unmute video" hidden>Unmute</button>
       </figure>
       <!-- Fallback thumbs (JS will rebuild these dynamically) -->
       <div class="gallery-thumbs" id="gallery-thumbs" role="list">

--- a/js/main.js
+++ b/js/main.js
@@ -103,11 +103,20 @@ const GALLERY_ITEMS = [
   const cap   = document.getElementById('g-cap');
   const thumbsWrap = document.getElementById('gallery-thumbs');
   const galleryMain = document.querySelector('.gallery-main');
+  const unmuteBtn = document.getElementById('unmuteBtn');
 
   let i = 0;
   let active = mainA;
   let standby = mainB;
   let timer = null;
+
+  function showUnmuteBtn(show){ if(unmuteBtn) unmuteBtn.hidden = !show; }
+  function handleUnmute(){
+    const vid = galleryMain.querySelector('.slide-vid');
+    if(vid){ vid.muted = false; vid.play(); }
+    showUnmuteBtn(false);
+  }
+  if(unmuteBtn){ unmuteBtn.addEventListener('click', handleUnmute); }
 
   function removeExistingVideo(){
     const existingVideo = galleryMain.querySelector('.slide-vid');
@@ -115,6 +124,7 @@ const GALLERY_ITEMS = [
       existingVideo.pause();
       existingVideo.remove();
     }
+    showUnmuteBtn(false);
   }
 
   function buildThumbs(){
@@ -152,6 +162,7 @@ const GALLERY_ITEMS = [
           video.autoplay = true;
           video.setAttribute('aria-label', t.alt || 'Video');
           galleryMain.appendChild(video);
+          showUnmuteBtn(true);
           // Update active index and UI state
           i = idx;
           stopTimer();


### PR DESCRIPTION
## Summary
- Add styled Unmute button overlay in gallery
- Allow users to enable audio on gallery videos with new unmute logic
- Move unmute button styles to stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a492abe7e4832881f538b1803f3896